### PR TITLE
Allow passing of additional 'Authorization' header

### DIFF
--- a/nginx/conf/sites/proxy.conf
+++ b/nginx/conf/sites/proxy.conf
@@ -16,6 +16,7 @@ server {
 
       proxy_set_header Cookie $upstream_cookies;
       proxy_set_header Host $http_host;
+      proxy_set_header Authorization $header_x_authorization;
       proxy_pass $proxy_pass;
     }
 
@@ -23,4 +24,9 @@ server {
     location = /50x.html {
         root   html;
     }
+}
+
+map $http_X_Authorization $header_x_authorization {
+  default "";
+  ~. $http_X_Authorization;
 }


### PR DESCRIPTION
If a client sends a `X-Authentication` header, the proxy will pass its value to the backend as a `Authentication` header.