### PR TITLE
Fix: support unnamed users

### DIFF
--- a/nginx/lua/auth.lua
+++ b/nginx/lua/auth.lua
@@ -41,5 +41,9 @@ end
 
 if features.user then
     if ngx.var.user_email then ngx.var.user_email = res.user.upn end
-    if ngx.var.user_name  then ngx.var.user_name = string.lower(res.user.given_name .. '.' .. res.user.family_name) end
+    if ngx.var.user_name then
+      ngx.var.user_name = ( res.user.given_name and res.user.family_name )
+        and string.lower( res.user.given_name .. '.' .. res.user.family_name )
+        or 'unnamed'
+    end
 end

--- a/nginx/lua/auth.lua
+++ b/nginx/lua/auth.lua
@@ -44,6 +44,6 @@ if features.user then
     if ngx.var.user_name then
       ngx.var.user_name = ( res.user.given_name and res.user.family_name )
         and string.lower( res.user.given_name .. '.' .. res.user.family_name )
-        or 'unnamed'
+        or res.user.upn
     end
 end


### PR DESCRIPTION
Add support for users with no name or surname (e.g. service accounts), which used to make openresty error out before this patch.